### PR TITLE
feat: Build & Upload cross-platform binaries as artifacts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
     branches: main
   pull_request:
     branches: main
+  workflow_dispatch: # Test
 
 jobs:
   deploy:
@@ -23,11 +24,20 @@ jobs:
         run: "deno test"
 
       - name: Build step
-        run: "deno compile --allow-read --allow-write --include src main.ts"
-    
+        run: |
+          deno compile --target x86_64-unknown-linux-gnu  --allow-read --allow-write --output tcx-ls-linux-x86_64       main.ts
+          deno compile --target aarch64-unknown-linux-gnu --allow-read --allow-write --output tcx-ls-linux-arm64        main.ts
+          deno compile --target aarch64-apple-darwin      --allow-read --allow-write --output tcx-ls-macos-arm64        main.ts
+          deno compile --target x86_64-apple-darwin       --allow-read --allow-write --output tcx-ls-macos-x86_64       main.ts
+          deno compile --target x86_64-pc-windows-msvc    --allow-read --allow-write --output tcx-ls-windows-x86_64.exe main.ts
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: tcx-ls Artifact
-          path: ./tcx-ls
-
+          path: |
+            tcx-ls-linux-x86_64
+            tcx-ls-linux-arm64
+            tcx-ls-macos-arm64
+            tcx-ls-macos-x86_64
+            tcx-ls-windows-x86_64.exe

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
     branches: main
   pull_request:
     branches: main
-  workflow_dispatch: # Test
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,12 +31,32 @@ jobs:
           deno compile --target x86_64-apple-darwin       --allow-read --allow-write --output tcx-ls-macos-x86_64       main.ts
           deno compile --target x86_64-pc-windows-msvc    --allow-read --allow-write --output tcx-ls-windows-x86_64.exe main.ts
 
-      - name: Upload artifact
-        uses: softprops/action-gh-release@v2
+      - name: Upload Linux x86_64
+        uses: actions/upload-artifact@v4
         with:
-          files: |
-            tcx-ls-linux-x86_64
-            tcx-ls-linux-arm64
-            tcx-ls-macos-arm64
-            tcx-ls-macos-x86_64
-            tcx-ls-windows-x86_64.exe
+          name: tcx-ls-linux-x86_64
+          path: ./tcx-ls-linux-x86_64
+
+      - name: Upload Linux arm64
+        uses: actions/upload-artifact@v4
+        with:
+          name: tcx-ls-linux-arm64
+          path: ./tcx-ls-linux-arm64
+
+      - name: Upload macOS arm64
+        uses: actions/upload-artifact@v4
+        with:
+          name: tcx-ls-macos-arm64
+          path: ./tcx-ls-macos-arm64
+
+      - name: Upload macOS x86_64
+        uses: actions/upload-artifact@v4
+        with:
+          name: tcx-ls-macos-x86_64
+          path: ./tcx-ls-macos-x86_64
+
+      - name: Upload Windows x86_64
+        uses: actions/upload-artifact@v4
+        with:
+          name: tcx-ls-windows-x86_64.exe
+          path: ./tcx-ls-windows-x86_64.exe

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,10 +32,9 @@ jobs:
           deno compile --target x86_64-pc-windows-msvc    --allow-read --allow-write --output tcx-ls-windows-x86_64.exe main.ts
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: softprops/action-gh-release@v2
         with:
-          name: tcx-ls Artifact
-          path: |
+          files: |
             tcx-ls-linux-x86_64
             tcx-ls-linux-arm64
             tcx-ls-macos-arm64


### PR DESCRIPTION
First of all, thanks for maintaining this great library! ..

## ✨ Changes
Ref: https://docs.deno.com/runtime/reference/cli/compile/#supported-targets
- **Added cross-platform builds**
  - `x86_64-unknown-linux-gnu`
  - `aarch64-unknown-linux-gnu`
  - `aarch64-apple-darwin`
  - `x86_64-apple-darwin`
  - `x86_64-pc-windows-msvc`
- **Upload artifacts per target**
  - Each platform binary is now uploaded as a separate artifact
  - Makes it easier for contributors to download only what they need

## 📸 Tests
Manually tested via `workflow_dispatch`:
<img width="1898" height="978" alt="image" src="https://github.com/user-attachments/assets/b0a55885-f11c-4214-8145-d194dd9a500c" />


## 💡 Further Considerations
- **macOS Universal build**  
  Could simplify distribution, but results in a much larger file size (~2×).
- **Windows ARM64 build**  
  Could be added later if there's interest — Deno supports cross-compilation.

## 📝 Notes
- Builds finish in ~30–35 seconds
